### PR TITLE
Replace the `params` field by `data` and add the required token permissions to `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ You must create a [Slack workspace](https://slack.com/get-started#/create)
 and obtain a [bot access token](https://api.slack.com/authentication/token-types#bot)
 before using the `slack` plugin.
 
+The Bot Access Token must have the following permissions:
+- `channels:manage`
+- `groups:write`
+- `im:write`
+- `mpim:write`
+- `channels:read`
+- `groups:read`
+- `mpim:read`
+- `im:read`
+
 ### Install the plugin
 
 microbs installs this plugin automatically when you [install microbs](https://microbs.io/docs/overview/getting-started/).

--- a/src/probe.js
+++ b/src/probe.js
@@ -16,7 +16,7 @@ module.exports.statusSlackChannel = async (channelName) => {
       method: 'get',
       url: 'https://slack.com/api/conversations.list',
       headers: constants.slackApiHeaders(),
-      params: {
+      data: {
         limit: 1000
       }
     })

--- a/src/setup.js
+++ b/src/setup.js
@@ -55,7 +55,7 @@ module.exports = async () => {
       response = await utils.http({
         method: 'post',
         url: 'https://slack.com/api/conversations.create',
-        params: {
+        data: {
           name: channelName
         },
         headers: constants.slackApiHeaders()


### PR DESCRIPTION
This pull request primarily focuses on enhancing the `slack` plugin functionality and updating the `README.md` file to reflect these changes. The most crucial changes involve the addition of required permissions for the Bot Access Token, and modifications to the `probe.js` and `setup.js` files in the `src` directory to change the method of data transfer from `params` to `data`.